### PR TITLE
Fixes #20 and #13

### DIFF
--- a/dashboard/src/scripts/components/MainOverview.react.js
+++ b/dashboard/src/scripts/components/MainOverview.react.js
@@ -7,7 +7,7 @@ var MainOverview = React.createClass({
         return (
             <div className="container">
                 <ul className="overview">
-                    {UIUtils.makeOverview(this.props.results)}
+                    {UIUtils.makeOverview(this.props.results, 'main')}
                 </ul>
             </div>
         );

--- a/dashboard/src/scripts/components/PublisherOverview.react.js
+++ b/dashboard/src/scripts/components/PublisherOverview.react.js
@@ -7,7 +7,7 @@ var PublisherOverview = React.createClass({
         return (
             <div className="container">
                 <ul className="overview">
-                    {UIUtils.makeOverview(this.props.results)}
+                    {UIUtils.makeOverview(this.props.results, 'publisher')}
                 </ul>
             </div>
         );

--- a/dashboard/src/scripts/components/pages/Main.react.js
+++ b/dashboard/src/scripts/components/pages/Main.react.js
@@ -60,7 +60,7 @@ var Main = React.createClass({
                         <MainChart results={this.state.results} />
                     </div>
                     <section className="publishers">
-                        <PublisherTable publishers={this.state.publishers} />
+                        <PublisherTable publishers={this.state.publishers} results={this.state.results} />
                     </section>
                 </div>
                 <FooterPanel instance={this.state.instance} />

--- a/dashboard/src/scripts/components/pages/Publisher.react.js
+++ b/dashboard/src/scripts/components/pages/Publisher.react.js
@@ -60,7 +60,7 @@ var Publisher = React.createClass({
                         <PublisherChart results={this.state.results} publisher={this.state.publisher} />
                     </div>
                     <section className="publishers">
-                        <SourceTable sources={this.state.sources}/>
+                        <SourceTable sources={this.state.sources}  results={this.state.results} />
                     </section>
                 </div>
                 <FooterPanel instance={this.state.instance} />

--- a/dashboard/src/scripts/components/pages/Publisher.react.js
+++ b/dashboard/src/scripts/components/pages/Publisher.react.js
@@ -19,7 +19,7 @@ function getStateFromStores(getParams) {
         instance: InstanceStore.get(),
         publisher: PublisherStore.get(getParams.lookup),
         results: ResultStore.query({'publisher_id': getParams.lookup}),
-        sources: SourceStore.all({'publisher_id': getParams.lookup})
+        sources: SourceStore.query({'publisher_id': getParams.lookup})
     };
 }
 

--- a/dashboard/src/scripts/components/tables/PublisherTable.react.js
+++ b/dashboard/src/scripts/components/tables/PublisherTable.react.js
@@ -28,10 +28,7 @@ var PublisherTable = React.createClass({
                         </tr>
                     </thead>
                     <tbody>
-                        {_.map(this.props.publishers, function(obj) {
-                            var _options = {'route': 'publishers'};
-                            return <tr key={obj.name}>{UIUtils.makeTableRow(obj, _options)}</tr>;
-                        })}
+                        {UIUtils.makeTableBody(this.props.publishers, this.props.results, {'route': 'publishers'})}
                     </tbody>
                 </Table>
             </div>

--- a/dashboard/src/scripts/components/tables/SourceTable.react.js
+++ b/dashboard/src/scripts/components/tables/SourceTable.react.js
@@ -30,10 +30,7 @@ var SourceTable = React.createClass({
                         </tr>
                     </thead>
                     <tbody>
-                        {_.map(this.props.sources, function(obj) {
-                            var _options = {'route': 'sources'};
-                            return <tr key={obj.id}>{UIUtils.makeTableRow(obj, _options)}</tr>;
-                        })}
+                        {UIUtils.makeTableBody(this.props.sources, this.props.results, {'route': 'sources'})}
                     </tbody>
                 </Table>
             </div>

--- a/dashboard/src/scripts/utils/CalcUtils.js
+++ b/dashboard/src/scripts/utils/CalcUtils.js
@@ -35,11 +35,50 @@ function totalScore(results) {
     return Math.round(_.reduce(scores, function(sum, n) {return sum + n;}) / results.length);
 }
 
+function publisherScore(publisher, results) {
+    var scores = [],
+        publisherScore = 'n/a';
+    // get all scores for this publisher from results
+    _.forEach(results, function(obj) {
+        if (obj.publisher_id === publisher) {
+            var score = obj.score ? obj.score : 0;
+            scores.push(parseInt(score));
+        }
+    });
+    // set the publisher score to: sum of scores / number of scores
+    if (scores.length > 0) {
+        publisherScore = Math.round(_.reduce(scores, function(sum, n) {return sum + n;}) / scores.length);
+    }
+    return publisherScore;
+}
+
+function sourceScore(source, results) {
+    var scores = [],
+        sourceScore = 'n/a';
+    // get all scores and timestamps for this source from results
+    _.forEach(results, function(obj) {
+        if (obj.source_id === source) {
+            var score = obj.score ? obj.score : 0;
+            var timestamp = Date.parse(obj.timestamp);
+            scores.push({'score': parseInt(score), 'timestamp': timestamp});
+        }
+    });
+    // set the source score to: the latest score
+    if (scores.length > 0) {
+        var latestScore = _.max(scores, function(elt) {
+            return elt.timestamp;
+        });
+        sourceScore = latestScore.score;
+    }
+    return sourceScore;
+}
 
 module.exports = {
     publisherCount: publisherCount,
     sourceCount: sourceCount,
     timelyPercent: timelyPercent,
     validPercent: validPercent,
-    totalScore: totalScore
+    totalScore: totalScore,
+    publisherScore: publisherScore,
+    sourceScore: sourceScore
 };

--- a/dashboard/src/scripts/utils/CalcUtils.js
+++ b/dashboard/src/scripts/utils/CalcUtils.js
@@ -19,12 +19,17 @@ function timelyPercent(results) {
 }
 
 function validPercent(results) {
+    var validPercent = 0;
     var valid = _.filter(results, function(obj) {
-        if (obj.score >= 9) {
+        var score = obj.score ? obj.score : 0;
+        if (score >= 9) {
             return obj;
         }
     });
-    return Math.round((valid.length / results.length) * 100);
+    if (results.length > 0) {
+        validPercent = Math.round((valid.length / results.length) * 100);
+    }
+    return validPercent;
 }
 
 function totalScore(results) {

--- a/dashboard/src/scripts/utils/CalcUtils.js
+++ b/dashboard/src/scripts/utils/CalcUtils.js
@@ -57,15 +57,16 @@ function publisherScore(publisher, results) {
     return publisherScore;
 }
 
+// return the latest score for a source and its timestamp from results
 function sourceScore(source, results) {
     var scores = [],
-        sourceScore = 0;
+        sourceScore = {score: 0, timestamp: 0};
     // get all scores and timestamps for this source from results
     _.forEach(results, function(obj) {
         if (obj.source_id === source) {
             var score = obj.score ? obj.score : 0;
             var timestamp = Date.parse(obj.timestamp);
-            scores.push({'score': parseInt(score), 'timestamp': timestamp});
+            scores.push({score: parseInt(score), timestamp: timestamp});
         }
     });
     // set the source score to: the latest score
@@ -73,7 +74,7 @@ function sourceScore(source, results) {
         var latestScore = _.max(scores, function(elt) {
             return elt.timestamp;
         });
-        sourceScore = latestScore.score;
+        sourceScore = latestScore;
     }
     return sourceScore;
 }

--- a/dashboard/src/scripts/utils/CalcUtils.js
+++ b/dashboard/src/scripts/utils/CalcUtils.js
@@ -22,7 +22,7 @@ function validPercent(results) {
     var validPercent = 0;
     var valid = _.filter(results, function(obj) {
         var score = obj.score ? obj.score : 0;
-        if (score >= 9) {
+        if (score == 10) {
             return obj;
         }
     });

--- a/dashboard/src/scripts/utils/CalcUtils.js
+++ b/dashboard/src/scripts/utils/CalcUtils.js
@@ -37,7 +37,7 @@ function totalScore(results) {
 
 function publisherScore(publisher, results) {
     var scores = [],
-        publisherScore = 'n/a';
+        publisherScore = 0;
     // get all scores for this publisher from results
     _.forEach(results, function(obj) {
         if (obj.publisher_id === publisher) {
@@ -54,7 +54,7 @@ function publisherScore(publisher, results) {
 
 function sourceScore(source, results) {
     var scores = [],
-        sourceScore = 'n/a';
+        sourceScore = 0;
     // get all scores and timestamps for this source from results
     _.forEach(results, function(obj) {
         if (obj.source_id === source) {

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -173,10 +173,11 @@ function makeTableBody(objects, results, options) {
             var _objWithScore = _.cloneDeep(obj);
             _objWithScore.score = _sourceData.score;
             _objWithScore.timestamp = _displayedTimestamp;
+            _objWithScore.refTimestamp = _sourceData.timestamp;
             return _objWithScore;
         });
-        // sort sources by score in descending order and by name in ascending order
-        _body = _.sortBy(_.sortBy(_unsorted, 'name').reverse(), 'score').reverse();
+        // sort sources by score and by date in descending order, then by publisher id and by name in ascending order
+        _body = _.sortByAll(_.sortByAll(_unsorted, ['publisher_id', 'name']).reverse(), ['score', 'refTimestamp']).reverse();
         // for each source, return a table row
         _body = _.map(_body, function(obj) {
             return <tr key={obj.id}>{makeTableRow(obj, options)}</tr>;

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -148,24 +148,41 @@ function makeTableHeader(obj) {
 }
 
 function makeTableBody(objects, results, options) {
-    var _body = [];
+    var _body = [],
+        _unsorted = [];
     if (options.route === 'publishers') {
-        // for each publisher, get its score from results and return a table row
-        _body = _.map(objects, function(obj) {
+        // for each publisher, get its score from results and return a new array of publishers with scores
+        _unsorted = _.map(objects, function(obj) {
             var _publisherScore = CalcUtils.publisherScore(obj.id, results);
-            return <tr key={obj.name}>{makeTableRow(obj, _publisherScore, options)}</tr>;
+            var _objWithScore = _.cloneDeep(obj);
+            _objWithScore.score = _publisherScore;
+            return _objWithScore;
+        });
+        // sort publishers by score in descending order and by name in ascending order
+        _body = _.sortBy(_.sortBy(_unsorted, 'name').reverse(), 'score').reverse();
+        // for each publisher, return a table row
+        _body = _.map(_body, function(obj) {
+            return <tr key={obj.name}>{makeTableRow(obj, options)}</tr>;
         });
     } else if (options.route === 'sources') {
-        // for each source, get its score from results and return a table row
-        _body = _.map(objects, function(obj) {
+        // for each source, get its score from results and return a new array of sources with scores
+        _unsorted = _.map(objects, function(obj) {
             var _sourceScore = CalcUtils.sourceScore(obj.id, results);
-            return <tr key={obj.id}>{makeTableRow(obj, _sourceScore, options)}</tr>;
+            var _objWithScore = _.cloneDeep(obj);
+            _objWithScore.score = _sourceScore;
+            return _objWithScore;
+        });
+        // sort sources by score in descending order and by name in ascending order
+        _body = _.sortBy(_.sortBy(_unsorted, 'name').reverse(), 'score').reverse();
+        // for each source, return a table row
+        _body = _.map(_body, function(obj) {
+            return <tr key={obj.id}>{makeTableRow(obj, options)}</tr>;
         });
     }
     return _body;
 }
 
-function makeTableRow(obj, score, options) {
+function makeTableRow(obj, options) {
     var _row = [];
     _.forEach(obj, function(value, key) {
         var _cell;
@@ -181,14 +198,14 @@ function makeTableRow(obj, score, options) {
         } else if (key === 'score') {
 
             var _c;
-            if (score <= 4) {
+            if (value <= 4) {
                 _c = 'danger';
-            } else if (score <= 8) {
+            } else if (value <= 8) {
                 _c = 'warning';
             } else {
                 _c = 'success';
             }
-            _cell = <td key={key} className={'score ' + _c}>{score}</td>;
+            _cell = <td key={key} className={'score ' + _c}>{value}</td>;
 
         } else if (key === 'name' || key === 'description' || key == 'contact' || key === 'jurisdiction_code' || key === 'revision' || key === 'timestamp' || key === 'publisher_id' || key === 'period_id') {
 

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -67,9 +67,9 @@ function makeOverview(results) {
             label: '% valid',
             value: CalcUtils.validPercent(results) + ''
         },
-        timelyPercent: {
-            label: '% timely',
-            value: CalcUtils.timelyPercent(results) + ''
+        invalidPercent: {
+            label: '% invalid',
+            value: (100 - CalcUtils.validPercent(results)) + ''
         }
     };
 

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -46,7 +46,7 @@ function makeOverviewCounter(label, number, counterPadding, digitWidth) {
     return <li className="counter" style={counterStyle}><span className="value">{makeOverviewNumber(number, digitWidth)}</span> <span className="label">{label}</span></li>;
 }
 
-function makeOverview(results) {
+function makeOverview(results, page) {
     var documentWidth = document.body.clientWidth,
         availableWidth = 0,
         counters = [],
@@ -54,24 +54,42 @@ function makeOverview(results) {
         digitCount = 0,
         spacePerDigit, digitMaxWidth, digitWidth, counterPadding;
 
-    var values = {
-        publisherCount: {
-            label: 'publishers',
-            value: CalcUtils.publisherCount(results) + ''
-        },
-        sourceCount: {
-            label: 'sources',
-            value: CalcUtils.sourceCount(results) + ''
-        },
-        validPercent: {
-            label: '% valid',
-            value: CalcUtils.validPercent(results) + ''
-        },
-        invalidPercent: {
-            label: '% invalid',
-            value: (100 - CalcUtils.validPercent(results)) + ''
-        }
-    };
+    if (page === 'main') {
+        var values = {
+            publisherCount: {
+                label: 'publishers',
+                value: CalcUtils.publisherCount(results) + ''
+            },
+            sourceCount: {
+                label: 'sources',
+                value: CalcUtils.sourceCount(results) + ''
+            },
+            validPercent: {
+                label: '% valid',
+                value: CalcUtils.validPercent(results) + ''
+            },
+            invalidPercent: {
+                label: '% invalid',
+                value: (100 - CalcUtils.validPercent(results)) + ''
+            }
+        };
+    } else if (page === 'publisher') {
+        var values = {
+            sourceCount: {
+                label: 'sources',
+                value: CalcUtils.sourceCount(results) + ''
+            },
+            validPercent: {
+                label: '% valid',
+                value: CalcUtils.validPercent(results) + ''
+            },
+            invalidPercent: {
+                label: '% invalid',
+                value: (100 - CalcUtils.validPercent(results)) + ''
+            }
+        };
+    }
+    
 
     if (documentWidth >= 980 && documentWidth < 1180) {
         availableWidth = 980;

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -165,11 +165,14 @@ function makeTableBody(objects, results, options) {
             return <tr key={obj.name}>{makeTableRow(obj, options)}</tr>;
         });
     } else if (options.route === 'sources') {
-        // for each source, get its score from results and return a new array of sources with scores
+        // for each source, get its score and timestamp from results and return a new array of sources with scores and timestamps
         _unsorted = _.map(objects, function(obj) {
-            var _sourceScore = CalcUtils.sourceScore(obj.id, results);
+            var _sourceData = CalcUtils.sourceScore(obj.id, results);
+            var _sourceTimestamp = new Date(_sourceData.timestamp);
+            var _displayedTimestamp = _sourceTimestamp.getFullYear() + '-' +  ('0' + (_sourceTimestamp.getMonth() + 1)).slice(-2) + '-' +  ('0' + _sourceTimestamp.getDate()).slice(-2);
             var _objWithScore = _.cloneDeep(obj);
-            _objWithScore.score = _sourceScore;
+            _objWithScore.score = _sourceData.score;
+            _objWithScore.timestamp = _displayedTimestamp;
             return _objWithScore;
         });
         // sort sources by score in descending order and by name in ascending order

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -147,7 +147,25 @@ function makeTableHeader(obj) {
     return _header;
 }
 
-function makeTableRow(obj, options) {
+function makeTableBody(objects, results, options) {
+    var _body = [];
+    if (options.route === 'publishers') {
+        // for each publisher, get its score from results and return a table row
+        _body = _.map(objects, function(obj) {
+            var _publisherScore = CalcUtils.publisherScore(obj.id, results);
+            return <tr key={obj.name}>{makeTableRow(obj, _publisherScore, options)}</tr>;
+        });
+    } else if (options.route === 'sources') {
+        // for each source, get its score from results and return a table row
+        _body = _.map(objects, function(obj) {
+            var _sourceScore = CalcUtils.sourceScore(obj.id, results);
+            return <tr key={obj.id}>{makeTableRow(obj, _sourceScore, options)}</tr>;
+        });
+    }
+    return _body;
+}
+
+function makeTableRow(obj, score, options) {
     var _row = [];
     _.forEach(obj, function(value, key) {
         var _cell;
@@ -163,14 +181,14 @@ function makeTableRow(obj, options) {
         } else if (key === 'score') {
 
             var _c;
-            if (value <= 4) {
+            if (score <= 4) {
                 _c = 'danger';
-            } else if (value <= 8) {
+            } else if (score <= 8) {
                 _c = 'warning';
             } else {
                 _c = 'success';
             }
-            _cell = <td key={key} className={'score ' + _c}>{value}</td>;
+            _cell = <td key={key} className={'score ' + _c}>{score}</td>;
 
         } else if (key === 'name' || key === 'description' || key == 'contact' || key === 'jurisdiction_code' || key === 'revision' || key === 'timestamp' || key === 'publisher_id' || key === 'period_id') {
 
@@ -276,7 +294,7 @@ module.exports = {
     makeOverviewNumber: makeOverviewNumber,
     makeOverview: makeOverview,
     makeTableHeader: makeTableHeader,
-    makeTableRow: makeTableRow,
+    makeTableBody: makeTableBody,
     filterTable: filterTable,
     makeScoreLinePayload: makeScoreLinePayload,
     makeScorePiePayload: makeScorePiePayload,

--- a/dashboard/src/scripts/utils/UIUtils.js
+++ b/dashboard/src/scripts/utils/UIUtils.js
@@ -200,7 +200,7 @@ function makeTableRow(obj, options) {
             var _c;
             if (value <= 4) {
                 _c = 'danger';
-            } else if (value <= 8) {
+            } else if (value <= 9) {
                 _c = 'warning';
             } else {
                 _c = 'success';


### PR DESCRIPTION
It does the following:
- Shows scores (captured in #20):
  - publishers scores in the publishers table:
    - score = sum of all publishers scores from results / number of scores
  - sources scores in the sources table:
    - score = latest score from results (based on timestamp)
  - files with score < 10 are invalid
- Shows performance over time on all pages with a line chart (captured in #20):
  - lines series for valid and invalid percentages:
    - by month for the last 12 months (based on timestamp from results)
- Sorts tables (captured in #13):
  - publishers table:
    - by score (descending) and by name (ascending)
  - sources table:
    - by score (descending), date (descending, based on timestamp from results), publisher id (ascending), name (ascending)
  - sorting also by publisher id and name made sense to me when looking at the tables but let me know if I should remove that
- Shows timestamp from results in sources table (instead of timestamp from sources)
- Switches timely % to invalid % in the overview section on the main page and on the publisher page (closes #23?)
- Removes sub-publishers count from the overview section on the publisher page
