### PR TITLE
Send empty param when schema is undefined

### DIFF
--- a/app/ui/scripts/utils/ui.js
+++ b/app/ui/scripts/utils/ui.js
@@ -267,6 +267,7 @@ function formatCell(key, value, obj, options) {
       }
       break
     case 'report':
+      if (!obj.schema) { obj.schema = ''}
       _cell = <td key="report"><a href={'http://goodtables.okfnlabs.org/reports?data_url=' + obj.data + '&format=' + obj.format + '&encoding=&schema_url=' + obj.schema}>{'Details'}</a></td>
       break
     case 'schema':


### PR DESCRIPTION
For databases that don't have schema, the schema parameter sent in the report request was `undefined` leading to this:
![error_shema_undefined](https://cloud.githubusercontent.com/assets/8862002/17648743/621f0b32-6229-11e6-9396-f1ff2c5a6e5e.png)
